### PR TITLE
Fix bug to return project by id and actions

### DIFF
--- a/data/helpers/projectModel.js
+++ b/data/helpers/projectModel.js
@@ -15,7 +15,7 @@ function get(id) {
     if (id) {
         query.where("p.id", id).first();
 
-        const promises = [query, this.getProjectActions(id)]; // [ projects, actions ]
+        const promises = [query, getProjectActions(id)]; // [ projects, actions ]
 
         return Promise.all(promises).then(function(results) {
             let [project, actions] = results;


### PR DESCRIPTION
Removed the **this** keyword from the **getProjectActions** function.
